### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,7 @@ const setupBSNavigate = () => {
 };
 
 const escapeBackQuote = (str: string) => {
-	return str.replace(/`/g, "\\`").replace(/\$\{/g, "\\${");
+	return str.replace(/\\/g, "\\\\").replace(/`/g, "\\`").replace(/\$\{/g, "\\${");
 };
 
 const setupCopyDataManager = () => {


### PR DESCRIPTION
Potential fix for [https://github.com/printf83/bsts-test/security/code-scanning/1](https://github.com/printf83/bsts-test/security/code-scanning/1)

To fix this safely without changing intended functionality, update `escapeBackQuote` in `src/index.ts` so it first escapes backslashes, then escapes backticks and `${`. Escaping backslashes first is important to avoid newly inserted backslashes being reprocessed incorrectly and to ensure existing backslashes in input cannot neutralize later escapes.

Best single change:
- In `src/index.ts`, replace the body of `escapeBackQuote` (lines 48–50 in the snippet) with a chained replacement that includes `/\\/g` first.
- No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
